### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,52 +6,52 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-SMTPClient 							KEYWORD1
-Mail 	 							KEYWORD1
+SMTPClient	KEYWORD1
+Mail	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-connect 							KEYWORD2
-setAuthLogin						KEYWORD2
-authLogin 							KEYWORD2
-ehlo								KEYWORD2
-mailFrom 							KEYWORD2
-rcptTo 								KEYWORD2
-data 								KEYWORD2
-body  								KEYWORD2
-finishData 							KEYWORD2
-quit 								KEYWORD2
-header 								KEYWORD2
-awaitSMTPResponse 					KEYWORD2
-send 								KEYWORD2
+connect	KEYWORD2
+setAuthLogin	KEYWORD2
+authLogin	KEYWORD2
+ehlo	KEYWORD2
+mailFrom	KEYWORD2
+rcptTo	KEYWORD2
+data	KEYWORD2
+body	KEYWORD2
+finishData	KEYWORD2
+quit	KEYWORD2
+header	KEYWORD2
+awaitSMTPResponse	KEYWORD2
+send	KEYWORD2
 
-from 								KEYWORD2
-replyTo 							KEYWORD2
-to 									KEYWORD2
-cc 									KEYWORD2
-bcc 								KEYWORD2
-subject 							KEYWORD2
-body 								KEYWORD2
-header								KEYWORD2
+from	KEYWORD2
+replyTo	KEYWORD2
+to	KEYWORD2
+cc	KEYWORD2
+bcc	KEYWORD2
+subject	KEYWORD2
+body	KEYWORD2
+header	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-SMTP_OK                        		LITERAL1
-SMTP_CLIENT_NOT_CONNECTED      		LITERAL1
-SMTP_CLIENT_ALREADY_CONNECTED   	LITERAL1
-SMTP_CLIENT_CANNOT_CONNECT      	LITERAL1
-SMTP_CONNECTION_ERROR           	LITERAL1
-SMTP_IDENTIFICATION_ERROR       	LITERAL1
-SMTP_AUTH_ERROR                 	LITERAL1
-SMTP_MAIL_FROM_ERROR            	LITERAL1
-SMTP_RCPT_TP_ERROR              	LITERAL1
-SMTP_DATA_ERROR                 	LITERAL1
-SMTP_BODY_ERROR                 	LITERAL1
-SMTP_QUIT_ERROR                 	LITERAL1
-SMTP_DATA_NOT_SENT              	LITERAL1
-SMTP_BODY_ALREADY_SENT          	LITERAL1
-SMTP_AUTH_NOT_SET                	LITERAL1
+SMTP_OK	LITERAL1
+SMTP_CLIENT_NOT_CONNECTED	LITERAL1
+SMTP_CLIENT_ALREADY_CONNECTED	LITERAL1
+SMTP_CLIENT_CANNOT_CONNECT	LITERAL1
+SMTP_CONNECTION_ERROR	LITERAL1
+SMTP_IDENTIFICATION_ERROR	LITERAL1
+SMTP_AUTH_ERROR	LITERAL1
+SMTP_MAIL_FROM_ERROR	LITERAL1
+SMTP_RCPT_TP_ERROR	LITERAL1
+SMTP_DATA_ERROR	LITERAL1
+SMTP_BODY_ERROR	LITERAL1
+SMTP_QUIT_ERROR	LITERAL1
+SMTP_DATA_NOT_SENT	LITERAL1
+SMTP_BODY_ALREADY_SENT	LITERAL1
+SMTP_AUTH_NOT_SET	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords